### PR TITLE
Switch to start_link/1 to support more arguments

### DIFF
--- a/lib/fwup.ex
+++ b/lib/fwup.ex
@@ -19,7 +19,9 @@ defmodule Fwup do
   end
 
   @doc "Stream firmware image to the device"
-  defdelegate stream(pid, args, opts \\ [name: Fwup.Stream]), to: Fwup.Stream, as: :start_link
+  def stream(pid, args, opts \\ [name: Fwup.Stream]) do
+    Fwup.Stream.start_link([cm: pid, fwup_args: args] ++ opts)
+  end
 
   defdelegate send_chunk(pid, chunk),
     to: Fwup.Stream


### PR DESCRIPTION
In prep for sending more parameters to the `fwup` call, this changes the
`start_link/3` call with positional arguments to `start_link/1` and
deprecates the 3-arg version.
