### PR TITLE
Add metadata command

### DIFF
--- a/lib/fwup/command.ex
+++ b/lib/fwup/command.ex
@@ -1,0 +1,28 @@
+defmodule Fwup.Command do
+  @moduledoc """
+  Execute one off fwup commands
+  """
+
+  @doc """
+  Get metadata from the specified fwup file
+
+  Options
+
+  * `:key_to_atom` - Convert metadata keys from strings to atoms, replaces "-" with "_"
+  """
+  @spec metadata(Path.t(), keyword()) :: {:ok, map()} | {:error, binary()}
+  def metadata(path, opts \\ []) do
+    case cmd(["-i", path, "-m"]) do
+      {res, 0} ->
+        {:ok, Fwup.Metadata.parse(res, opts)}
+
+      {res, _} ->
+        {:error, res}
+    end
+  end
+
+  @spec cmd([binary]) :: {binary(), non_neg_integer}
+  defp cmd(args) do
+    System.cmd(Fwup.exe(), args)
+  end
+end

--- a/lib/fwup/metadata.ex
+++ b/lib/fwup/metadata.ex
@@ -1,0 +1,41 @@
+defmodule Fwup.Metadata do
+  @moduledoc """
+  Fwup Metadata
+  """
+
+  @doc """
+  Parse metadata string to a map
+
+  Options
+
+  * `:key_to_atom` - Convert metadata keys from strings to atoms, replaces "-" with "_"
+  """
+  @spec parse(binary(), keyword()) :: map()
+  def parse(str, opts \\ []) do
+    str
+    |> String.split("\n", trim: true)
+    |> Enum.map(fn entry ->
+      [key, val] = String.split(entry, "=", parts: 2, trim: true)
+
+      key =
+        key
+        |> String.trim_leading("meta-")
+
+      key =
+        if opts[:keys_to_atoms] do
+          key
+          |> String.replace("-", "_")
+          |> String.to_atom()
+        else
+          key
+        end
+
+      val =
+        val
+        |> String.trim("\"")
+
+      {key, val}
+    end)
+    |> Map.new()
+  end
+end

--- a/test/fwup/command_test.exs
+++ b/test/fwup/command_test.exs
@@ -1,0 +1,36 @@
+defmodule Fwup.CommandTest do
+  use ExUnit.Case
+  alias Fwup.TestSupport.Fixtures
+
+  test "metadata" do
+    {:ok, fw_path} = Fixtures.create_firmware("test")
+    {:ok, metadata} = Fwup.Command.metadata(fw_path)
+
+    assert metadata == %{
+             "architecture" => "x86_64",
+             "author" => "me",
+             "creation-date" => "1970-01-01T00:00:00Z",
+             "description" => "D ",
+             "platform" => "platform",
+             "product" => "nerves-hub",
+             "uuid" => "f46925cb-7c7b-5aae-10fb-a93c09941b60",
+             "version" => "1.0.0"
+           }
+  end
+
+  test "metadata converts keys to atoms" do
+    {:ok, fw_path} = Fixtures.create_firmware("test")
+    {:ok, metadata} = Fwup.Command.metadata(fw_path, keys_to_atoms: true)
+
+    assert metadata == %{
+             architecture: "x86_64",
+             author: "me",
+             creation_date: "1970-01-01T00:00:00Z",
+             description: "D ",
+             platform: "platform",
+             product: "nerves-hub",
+             uuid: "f46925cb-7c7b-5aae-10fb-a93c09941b60",
+             version: "1.0.0"
+           }
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -58,13 +58,20 @@ defmodule Fwup.TestSupport.Fixtures do
     out_path = Path.join([System.tmp_dir(), firmware_name <> ".fw"])
     File.rm(out_path)
 
-    System.cmd("fwup", [
-      "-c",
-      "-f",
-      conf_path,
-      "-o",
-      out_path
-    ])
+    # SOURCE_DATE_EPOCH ensures fwup produces reproducible builds.
+    # Specifically, this will pin the creation-time metadata value.
+    {_, 0} =
+      System.cmd(
+        "fwup",
+        [
+          "-c",
+          "-f",
+          conf_path,
+          "-o",
+          out_path
+        ],
+        env: [{"SOURCE_DATE_EPOCH", "0"}]
+      )
 
     {:ok, out_path}
   end


### PR DESCRIPTION
Adds support for parsing metadata from a fwup archive into an Elixir map.

This doesn't utilize stream and instead adds a Command module for one-off commands on local files. Seemingly stream is primarily meant for applying firmware archives and not for inspecting them.

Also configures fwup to produce reproducible builds during tests.